### PR TITLE
refactor layouts and routing imports

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,3 +11,8 @@ body {
 .page-content {
   margin: 0 10%;
 }
+.home-link {
+  left: 0;
+  position: fixed;
+  z-index: 999;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,9 @@
 import "./App.css";
-import { useState } from "react";
 import { Route, Routes } from "react-router-dom";
-import { Outlet } from "react-router-dom";
-import { Link } from "react-router-dom";
 
-import { Navbar } from "./components/Navbar";
-import { About, Events, Games, Home, Join } from "./components/pages";
+import { About, Events, Games, Join } from "./components/pages";
+import MainLayout from "./layout/MainLayout";
+import GameLayout from "./layout/GameLayout";
 
 // Games
 import SnakeOnPage from "@isaacindex/snake-on-page";
@@ -17,30 +15,6 @@ import SnakeOnPage from "@isaacindex/snake-on-page";
 import GameScreen from "./other-games/screens/gameScreen";
 import TextClassificationGame from "./other-games/screens/textClassification";
 import HealthQuiz from "./other-games/screens/healthQuiz";
-
-// Main layout component with navbar
-const MainLayout = () => {
-  return (
-    <>
-      <Navbar />
-      <div className="page-content">
-        <Outlet />
-      </div>
-    </>
-  );
-};
-
-// Layout component without navbar
-const GameLayout = () => {
-  return (
-    <>
-      <Link to="/" style={{ left: 0, position: "fixed", zIndex: 999 }}>
-        Home
-      </Link>
-      <Outlet />
-    </>
-  );
-};
 
 function App() {
   return (

--- a/src/layout/GameLayout.jsx
+++ b/src/layout/GameLayout.jsx
@@ -1,0 +1,14 @@
+import { Outlet, Link } from 'react-router-dom';
+
+const GameLayout = () => {
+  return (
+    <>
+      <Link to="/" className="home-link">
+        Home
+      </Link>
+      <Outlet />
+    </>
+  );
+};
+
+export default GameLayout;

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom';
+import { Navbar } from '../components/Navbar';
+
+const MainLayout = () => {
+  return (
+    <>
+      <Navbar />
+      <div className="page-content">
+        <Outlet />
+      </div>
+    </>
+  );
+};
+
+export default MainLayout;


### PR DESCRIPTION
## Summary
- extract MainLayout and GameLayout into dedicated layout components
- consolidate react-router-dom imports and remove unused useState
- move Home link styling to App.css

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 80 errors, 9 warnings)*
- `npx eslint src/App.jsx src/layout/MainLayout.jsx src/layout/GameLayout.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac0a024c00832b8406c55bee528d2e