### PR TITLE
refactor navbar into menu and social components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "bootstrap": "^5.3.2",
         "firebase": "^10.7.1",
         "is-number": "^7.0.0",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.1",
         "react-dom": "^18.2.0",
@@ -16355,6 +16356,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bootstrap": "^5.3.2",
     "firebase": "^10.7.1",
     "is-number": "^7.0.0",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.1",
     "react-dom": "^18.2.0",

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,28 +1,12 @@
 import styles from "./Navbar.module.css";
-import React, { useState } from "react";
-import { Link, NavLink } from "react-router-dom";
+import { useState } from "react";
+import { Link } from "react-router-dom";
 import logo from "../assets/logo.png";
-
-// import ICONS from "../assets/social_media";
+import MenuItems from "./Navbar/MenuItems";
+import SocialLinks from "./Navbar/SocialLinks";
 
 export const Navbar = () => {
   const [menuOpen, setMenuOpen] = useState(false);
-
-  const menuItems = [
-    // { to: "/about-foresee", label: "About Foresee" },
-    { to: "/", label: "About Foresee" },
-    { to: "/join-foresee", label: "Join Foresee" },
-    { to: "/events", label: "Events" },
-    { to: "/educational-games", label: "Games" },
-  ];
-
-  const icons = [
-    "src/assets/social_media/EmailUs.svg",
-    "src/assets/social_media/Facebook.svg",
-    "src/assets/social_media/Instagram.svg",
-    "src/assets/social_media/LinkedIn.svg",
-    "src/assets/social_media/Youtube.svg",
-  ];
 
   return (
     <nav className={styles.nav}>
@@ -43,21 +27,8 @@ export const Navbar = () => {
         <span className={styles.bar}></span>
       </div>
       <ul className={menuOpen ? styles.open : ""}>
-        {menuItems.map((item, index) => (
-          <li key={index} onClick={() => setMenuOpen(!menuOpen)}>
-            <NavLink
-              className={({ isActive }) => (isActive ? styles.linkActive : "")}
-              to={item.to}
-            >
-              {item.label}
-            </NavLink>
-          </li>
-        ))}
-        <div className={styles.iconsDiv}>
-          {icons.map((src, index) => (
-            <img height={"30px"} key={index} src={src} alt={`Image ${index}`} />
-          ))}
-        </div>
+        <MenuItems menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+        <SocialLinks menuOpen={menuOpen} />
       </ul>
     </nav>
   );

--- a/src/components/Navbar/MenuItems.jsx
+++ b/src/components/Navbar/MenuItems.jsx
@@ -1,0 +1,34 @@
+import { NavLink } from "react-router-dom";
+import PropTypes from "prop-types";
+import styles from "../Navbar.module.css";
+
+const items = [
+  { to: "/", label: "About Foresee" },
+  { to: "/join-foresee", label: "Join Foresee" },
+  { to: "/events", label: "Events" },
+  { to: "/educational-games", label: "Games" },
+];
+
+export const MenuItems = ({ menuOpen, setMenuOpen }) => {
+  return (
+    <>
+      {items.map((item, index) => (
+        <li key={index} onClick={() => setMenuOpen(!menuOpen)}>
+          <NavLink
+            className={({ isActive }) => (isActive ? styles.linkActive : "")}
+            to={item.to}
+          >
+            {item.label}
+          </NavLink>
+        </li>
+      ))}
+    </>
+  );
+};
+
+MenuItems.propTypes = {
+  menuOpen: PropTypes.bool.isRequired,
+  setMenuOpen: PropTypes.func.isRequired,
+};
+
+export default MenuItems;

--- a/src/components/Navbar/SocialLinks.jsx
+++ b/src/components/Navbar/SocialLinks.jsx
@@ -1,0 +1,31 @@
+import styles from "../Navbar.module.css";
+import PropTypes from "prop-types";
+import EmailIcon from "../../assets/social_media/EmailUs.svg";
+import FacebookIcon from "../../assets/social_media/Facebook.svg";
+import InstagramIcon from "../../assets/social_media/Instagram.svg";
+import LinkedInIcon from "../../assets/social_media/LinkedIn.svg";
+import YoutubeIcon from "../../assets/social_media/Youtube.svg";
+
+const icons = [
+  { src: EmailIcon, alt: "Email" },
+  { src: FacebookIcon, alt: "Facebook" },
+  { src: InstagramIcon, alt: "Instagram" },
+  { src: LinkedInIcon, alt: "LinkedIn" },
+  { src: YoutubeIcon, alt: "Youtube" },
+];
+
+export const SocialLinks = ({ menuOpen }) => {
+  return (
+    <div className={styles.iconsDiv} data-open={menuOpen}>
+      {icons.map((icon, index) => (
+        <img height="30px" key={index} src={icon.src} alt={icon.alt} />
+      ))}
+    </div>
+  );
+};
+
+SocialLinks.propTypes = {
+  menuOpen: PropTypes.bool.isRequired,
+};
+
+export default SocialLinks;


### PR DESCRIPTION
## Summary
- extract menu list and social link icons into dedicated Navbar subcomponents
- pass menu state to new components and import icons as modules

## Testing
- `npm run lint` *(fails: 90 problems (81 errors, 9 warnings))*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac0a0186fc832b95d52927006355fe